### PR TITLE
Look in all global GIT config files for GitLab URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     description='gitlab for git',
     packages=['gitgitlab'],
     install_requires=['gitpython==0.3.2.RC1', 'keyring==3.3', 'opster==4.1', 'python-gitlab==0.6',
-                      'requests==2.2.1'],
+                      'requests==2.2.1', 'pyxdg==0.25'],
     entry_points={'console_scripts': ['git-lab=gitgitlab.cli:git']}
 )


### PR DESCRIPTION
Look in all global GIT config files for the GitLab URL, as listed in section FILES on https://git-scm.herokuapp.com/docs/git-config.

Fixes #6

The modification to `get_global_config_parser` is ugly because a writeable config can't have multiple sources. Suggestions for improvements are welcome.
